### PR TITLE
added fix for selector matching

### DIFF
--- a/components/layout/src/box_layout.rs
+++ b/components/layout/src/box_layout.rs
@@ -52,7 +52,8 @@ fn layout_children(root: &mut LayoutBox) {
         layout(child, &mut containing_block);
 
         let child_margin_height = child.dimensions.margin_box_height();
-        containing_block.height += child_margin_height - containing_block.collapsed_margins_vertical;
+        containing_block.height +=
+            child_margin_height - containing_block.collapsed_margins_vertical;
         containing_block.offset_y += child_margin_height - child.dimensions.margin.bottom;
     }
     let computed_height = root.render_node.borrow().get_style(&Property::Height);
@@ -121,9 +122,7 @@ fn place_block_in_flow(root: &mut LayoutBox, containing_block: &mut ContainingBl
         border_bottom.to_px(containing_block.width),
     );
 
-    let x = box_model.margin.left
-        + box_model.border.left
-        + containing_block.offset_x;
+    let x = box_model.margin.left + box_model.border.left + containing_block.offset_x;
 
     let (collapse_margin, collapsed) = {
         let margin_bottom = containing_block.previous_margin_bottom;
@@ -150,9 +149,7 @@ fn place_block_in_flow(root: &mut LayoutBox, containing_block: &mut ContainingBl
         }
     };
 
-    let y = collapse_margin
-        + box_model.border.top
-        + containing_block.offset_y;
+    let y = collapse_margin + box_model.border.top + containing_block.offset_y;
 
     containing_block.previous_margin_bottom = box_model.margin.bottom;
     containing_block.collapsed_margins_vertical += collapsed;
@@ -385,7 +382,7 @@ mod tests {
                 offset_y: 0.0,
                 previous_margin_bottom: 0.0,
                 collapsed_margins_vertical: 0.0,
-            }
+            },
         );
 
         print_layout_tree(&layout_tree, 0);
@@ -448,7 +445,7 @@ mod tests {
                 offset_y: 0.0,
                 previous_margin_bottom: 0.0,
                 collapsed_margins_vertical: 0.0,
-            }
+            },
         );
 
         print_layout_tree(&layout_tree, 0);
@@ -539,7 +536,7 @@ mod tests {
                 offset_y: 0.0,
                 previous_margin_bottom: 0.0,
                 collapsed_margins_vertical: 0.0,
-            }
+            },
         );
 
         print_layout_tree(&layout_tree, 0);

--- a/components/painting/src/components/mod.rs
+++ b/components/painting/src/components/mod.rs
@@ -1,5 +1,5 @@
-pub mod rect;
 pub mod paint;
+pub mod rect;
 
-pub use rect::Rect;
 pub use paint::*;
+pub use rect::Rect;

--- a/components/painting/src/components/paint.rs
+++ b/components/painting/src/components/paint.rs
@@ -1,13 +1,13 @@
 #[derive(Debug)]
 pub struct Paint {
     pub style: PaintStyle,
-    pub color: PaintColor
+    pub color: PaintColor,
 }
 
 #[derive(Debug)]
 pub enum PaintStyle {
     Fill,
-    Stroke
+    Stroke,
 }
 
 #[derive(Debug)]
@@ -15,7 +15,7 @@ pub struct PaintColor {
     pub r: u8,
     pub g: u8,
     pub b: u8,
-    pub a: u8
+    pub a: u8,
 }
 
 impl Default for PaintColor {
@@ -24,7 +24,7 @@ impl Default for PaintColor {
             r: 0,
             g: 0,
             b: 0,
-            a: 0
+            a: 0,
         }
     }
 }

--- a/components/painting/src/components/rect.rs
+++ b/components/painting/src/components/rect.rs
@@ -3,5 +3,5 @@ pub struct Rect {
     pub x: f32,
     pub y: f32,
     pub width: f32,
-    pub height: f32
+    pub height: f32,
 }

--- a/components/painting/src/lib.rs
+++ b/components/painting/src/lib.rs
@@ -8,7 +8,7 @@ use render::render_layout_box;
 
 #[derive(Debug)]
 pub enum DisplayCommand {
-    DrawRect(Rect, Paint)
+    DrawRect(Rect, Paint),
 }
 
 pub type DisplayList = Vec<DisplayCommand>;
@@ -19,7 +19,8 @@ pub trait Painter<Canvas> {
 }
 
 pub fn paint<P, C>(root: &LayoutBox, painter: &mut P, canvas: &mut C)
-    where P: Painter<C>
+where
+    P: Painter<C>,
 {
     let display_list = build_display_list(root);
 
@@ -38,14 +39,11 @@ fn build_display_list(root: &LayoutBox) -> DisplayList {
     display_list
 }
 
-fn execute_display_command<P, C>(
-    command: DisplayCommand,
-    painter: &mut P,
-    canvas: &mut C
-)
-    where P: Painter<C>
+fn execute_display_command<P, C>(command: DisplayCommand, painter: &mut P, canvas: &mut C)
+where
+    P: Painter<C>,
 {
     match command {
-        DisplayCommand::DrawRect(rect, paint) => painter.paint_rect(rect, paint, canvas)
+        DisplayCommand::DrawRect(rect, paint) => painter.paint_rect(rect, paint, canvas),
     }
 }

--- a/components/painting/src/render.rs
+++ b/components/painting/src/render.rs
@@ -1,10 +1,10 @@
-use layout::layout_box::LayoutBox;
-use super::{DisplayCommand, DisplayList};
+use super::components::paint::{Paint, PaintColor, PaintStyle};
 use super::components::Rect;
-use super::components::paint::{Paint, PaintStyle, PaintColor};
+use super::{DisplayCommand, DisplayList};
+use layout::layout_box::LayoutBox;
 use style::value_processing::Property;
-use style::values::color::Color;
 use style::value_processing::Value;
+use style::values::color::Color;
 
 pub fn render_layout_box(root: &LayoutBox, display_list: &mut DisplayList) {
     render_background(root, display_list);
@@ -21,7 +21,7 @@ fn render_background(root: &LayoutBox, display_list: &mut DisplayList) {
 
     let paint = Paint {
         style: PaintStyle::Fill,
-        color: style_color_to_paint_color(background.inner()).unwrap_or_default()
+        color: style_color_to_paint_color(background.inner()).unwrap_or_default(),
     };
 
     let rect_width = root.dimensions.content.width
@@ -36,7 +36,7 @@ fn render_background(root: &LayoutBox, display_list: &mut DisplayList) {
         x: root.dimensions.content.x,
         y: root.dimensions.content.y,
         width: rect_width,
-        height: rect_height
+        height: rect_height,
     };
 
     display_list.push(DisplayCommand::DrawRect(rect, paint));
@@ -45,7 +45,7 @@ fn render_background(root: &LayoutBox, display_list: &mut DisplayList) {
 fn style_color_to_paint_color(style_color: &Value) -> Option<PaintColor> {
     let color = match style_color {
         Value::Color(c) => c,
-        _ => return None
+        _ => return None,
     };
 
     match color {
@@ -55,9 +55,9 @@ fn style_color_to_paint_color(style_color: &Value) -> Option<PaintColor> {
                 r: r.as_u8(),
                 g: g.as_u8(),
                 b: b.as_u8(),
-                a: alpha
+                a: alpha,
             })
         }
-        _ => None
+        _ => None,
     }
 }

--- a/components/style/src/render_tree.rs
+++ b/components/style/src/render_tree.rs
@@ -162,9 +162,12 @@ pub fn build_render_tree(node: NodeRef, rules: &[ContextualRule]) -> RenderTree 
 
     if let Some(node) = render_root {
         let root = build_render_tree_from_node(node, rules, None, &mut style_cache);
-        return RenderTree { root, style_cache }
+        return RenderTree { root, style_cache };
     }
-    RenderTree { root: None, style_cache }
+    RenderTree {
+        root: None,
+        style_cache,
+    }
 }
 
 /// Build the render tree using the root node & list of stylesheets

--- a/components/style/src/selector_matching.rs
+++ b/components/style/src/selector_matching.rs
@@ -3,7 +3,13 @@ use dom::dom_ref::NodeRef;
 use dom::element::Element;
 
 fn get_parent(el: &NodeRef) -> Option<NodeRef> {
-    el.borrow().as_node().parent()
+    let parent = el.borrow().as_node().parent();
+    if let Some(p) = parent {
+        if p.is_element() {
+            return Some(p);
+        }
+    }
+    None
 }
 
 fn get_prev_sibling(el: &NodeRef) -> Option<NodeRef> {

--- a/components/style/src/value_processing.rs
+++ b/components/style/src/value_processing.rs
@@ -170,9 +170,7 @@ impl ValueRef {
         match self.borrow() {
             Value::Length(l) => l.to_px(),
             Value::Percentage(p) => p.to_px(relative_to),
-            _ => {
-                0.0
-            }
+            _ => 0.0,
         }
     }
 }

--- a/rendering/src/main.rs
+++ b/rendering/src/main.rs
@@ -1,12 +1,12 @@
 mod painter;
 
 use css::cssom::css_rule::CSSRule;
-use style::value_processing::{ContextualRule, CSSLocation, CascadeOrigin};
-use style::render_tree::build_render_tree;
-use layout::{build_layout_tree, ContainingBlock, layout_box::LayoutBox};
-use painting::paint;
+use layout::{build_layout_tree, layout_box::LayoutBox, ContainingBlock};
 use painter::SkiaPainter;
+use painting::paint;
 use skulpin::winit;
+use style::render_tree::build_render_tree;
+use style::value_processing::{CSSLocation, CascadeOrigin, ContextualRule};
 
 fn print_layout_tree(root: &LayoutBox, level: usize) {
     let child_nodes = &root.children;
@@ -66,16 +66,19 @@ fn main() {
 
     let logical_size = winit::dpi::LogicalSize::new(500.0, 300.0);
 
-    layout::layout(&mut layout_tree, &mut ContainingBlock {
-        offset_x: 0.,
-        offset_y: 0.,
-        x: 0.,
-        y: 0.,
-        width: logical_size.width,
-        height: logical_size.height,
-        previous_margin_bottom: 0.0,
-        collapsed_margins_vertical: 0.0
-    });
+    layout::layout(
+        &mut layout_tree,
+        &mut ContainingBlock {
+            offset_x: 0.,
+            offset_y: 0.,
+            x: 0.,
+            y: 0.,
+            width: logical_size.width,
+            height: logical_size.height,
+            previous_margin_bottom: 0.0,
+            collapsed_margins_vertical: 0.0,
+        },
+    );
 
     print_layout_tree(&layout_tree, 0);
 

--- a/rendering/src/painter.rs
+++ b/rendering/src/painter.rs
@@ -1,26 +1,19 @@
-use painting::{Painter, Rect, Paint, PaintStyle, PaintColor};
-use skulpin::skia_safe::Canvas;
+use painting::{Paint, PaintColor, PaintStyle, Painter, Rect};
 use skulpin::skia_safe;
+use skulpin::skia_safe::Canvas;
 
 pub struct SkiaPainter {
-    paint: skia_safe::Paint
+    paint: skia_safe::Paint,
 }
 
 impl SkiaPainter {
     pub fn new() -> Self {
         let paint = skia_safe::Paint::new(skia_safe::Color4f::new(0., 0., 0., 0.), None);
-        Self {
-            paint
-        }
+        Self { paint }
     }
 
     pub fn translate_color(color: PaintColor) -> skia_safe::Color {
-        skia_safe::Color::from_argb(
-            color.a,
-            color.r,
-            color.g,
-            color.b
-        )
+        skia_safe::Color::from_argb(color.a, color.r, color.g, color.b)
     }
 }
 
@@ -28,21 +21,23 @@ impl Painter<Canvas> for SkiaPainter {
     fn paint_rect(&mut self, rect: Rect, paint: Paint, canvas: &mut Canvas) {
         self.paint.set_style(match paint.style {
             PaintStyle::Fill => skia_safe::PaintStyle::Fill,
-            PaintStyle::Stroke => skia_safe::PaintStyle::Stroke
+            PaintStyle::Stroke => skia_safe::PaintStyle::Stroke,
         });
 
         self.paint.set_color(Self::translate_color(paint.color));
 
-        canvas.draw_rect(skia_safe::Rect {
-            left: rect.x,
-            top: rect.y,
-            right: rect.x + rect.width,
-            bottom: rect.y + rect.height
-        }, &self.paint);
+        canvas.draw_rect(
+            skia_safe::Rect {
+                left: rect.x,
+                top: rect.y,
+                right: rect.x + rect.width,
+                bottom: rect.y + rect.height,
+            },
+            &self.paint,
+        );
     }
 
     fn clear(&mut self, canvas: &mut Canvas) {
         canvas.clear(skia_safe::Color::from_argb(255, 255, 255, 255));
     }
 }
-


### PR DESCRIPTION
When performing selector matching, the browser may traverse up to the parent of a node. This process may cause it to match with a `Document`, which is the parent of the `html` tag. This will lead to crashing so we will stop the parent bubbling at the `html` element.