### PR TITLE
Refactor containing block

### DIFF
--- a/components/layout/src/box_layout.rs
+++ b/components/layout/src/box_layout.rs
@@ -380,7 +380,7 @@ mod tests {
                     x: 0.0,
                     y: 0.0,
                     width: 1200.0,
-                    height: 600.0
+                    height: 600.0,
                 },
                 offset_x: 0.0,
                 offset_y: 0.0,
@@ -445,7 +445,7 @@ mod tests {
                     x: 0.0,
                     y: 0.0,
                     width: 1200.0,
-                    height: 600.0
+                    height: 600.0,
                 },
                 offset_x: 0.0,
                 offset_y: 0.0,
@@ -538,7 +538,7 @@ mod tests {
                     x: 0.0,
                     y: 0.0,
                     width: 1200.0,
-                    height: 600.0
+                    height: 600.0,
                 },
                 offset_x: 0.0,
                 offset_y: 0.0,

--- a/components/layout/src/box_layout.rs
+++ b/components/layout/src/box_layout.rs
@@ -3,7 +3,7 @@
 /// 1. Box width calculation
 /// 2. Box position calculation
 /// 3. Box height calculation
-use super::box_model::{BoxComponent, Edge};
+use super::box_model::{BoxComponent, Edge, Rect};
 use super::layout_box::{BoxType, FormattingContext, LayoutBox};
 use super::{
     is_absolutely_positioned, is_block_level_element, is_float_element, is_in_normal_flow,
@@ -13,10 +13,7 @@ use style::value_processing::Property;
 
 #[derive(Debug)]
 pub struct ContainingBlock {
-    pub x: f32,
-    pub y: f32,
-    pub width: f32,
-    pub height: f32,
+    pub rect: Rect,
     pub offset_x: f32,
     pub offset_y: f32,
     pub previous_margin_bottom: f32,
@@ -36,12 +33,12 @@ fn apply_explicit_sizes(root: &mut LayoutBox, containing_block: &mut ContainingB
     let computed_height = root.render_node.borrow().get_style(&Property::Height);
 
     if !computed_width.is_auto() {
-        let used_width = computed_width.to_px(containing_block.width);
+        let used_width = computed_width.to_px(containing_block.rect.width);
         root.box_model().set_width(used_width);
     }
 
     if !computed_height.is_auto() {
-        let used_height = computed_height.to_px(containing_block.height);
+        let used_height = computed_height.to_px(containing_block.rect.height);
         root.box_model().set_height(used_height);
     }
 }
@@ -52,13 +49,13 @@ fn layout_children(root: &mut LayoutBox) {
         layout(child, &mut containing_block);
 
         let child_margin_height = child.dimensions.margin_box_height();
-        containing_block.height +=
+        containing_block.rect.height +=
             child_margin_height - containing_block.collapsed_margins_vertical;
         containing_block.offset_y += child_margin_height - child.dimensions.margin.bottom;
     }
     let computed_height = root.render_node.borrow().get_style(&Property::Height);
     if computed_height.is_auto() {
-        root.box_model().set_height(containing_block.height);
+        root.box_model().set_height(containing_block.rect.height);
     }
 }
 
@@ -92,34 +89,34 @@ fn place_block_in_flow(root: &mut LayoutBox, containing_block: &mut ContainingBl
     box_model.set(
         BoxComponent::Margin,
         Edge::Top,
-        margin_top.to_px(containing_block.width),
+        margin_top.to_px(containing_block.rect.width),
     );
     box_model.set(
         BoxComponent::Margin,
         Edge::Bottom,
-        margin_bottom.to_px(containing_block.width),
+        margin_bottom.to_px(containing_block.rect.width),
     );
 
     box_model.set(
         BoxComponent::Padding,
         Edge::Top,
-        padding_top.to_px(containing_block.width),
+        padding_top.to_px(containing_block.rect.width),
     );
     box_model.set(
         BoxComponent::Padding,
         Edge::Bottom,
-        padding_bottom.to_px(containing_block.width),
+        padding_bottom.to_px(containing_block.rect.width),
     );
 
     box_model.set(
         BoxComponent::Border,
         Edge::Top,
-        border_top.to_px(containing_block.width),
+        border_top.to_px(containing_block.rect.width),
     );
     box_model.set(
         BoxComponent::Border,
         Edge::Bottom,
-        border_bottom.to_px(containing_block.width),
+        border_bottom.to_px(containing_block.rect.width),
     );
 
     let content_area_x = containing_block.offset_x
@@ -180,7 +177,7 @@ fn compute_width(root: &mut LayoutBox, containing_block: &ContainingBlock) {
     let computed_border_right = render_node.get_style(&Property::BorderRightWidth);
     let computed_padding_left = render_node.get_style(&Property::PaddingLeft);
     let computed_padding_right = render_node.get_style(&Property::PaddingRight);
-    let containing_width = containing_block.width;
+    let containing_width = containing_block.rect.width;
 
     let box_width = computed_margin_left.to_px(containing_width)
         + computed_border_left.to_px(containing_width)
@@ -379,10 +376,12 @@ mod tests {
         compute_width(
             &mut layout_tree,
             &mut ContainingBlock {
-                x: 0.0,
-                y: 0.0,
-                width: 1200.0,
-                height: 600.0,
+                rect: Rect {
+                    x: 0.0,
+                    y: 0.0,
+                    width: 1200.0,
+                    height: 600.0
+                },
                 offset_x: 0.0,
                 offset_y: 0.0,
                 previous_margin_bottom: 0.0,
@@ -442,10 +441,12 @@ mod tests {
         layout(
             &mut layout_tree,
             &mut ContainingBlock {
-                x: 0.0,
-                y: 0.0,
-                width: 1200.0,
-                height: 600.0,
+                rect: Rect {
+                    x: 0.0,
+                    y: 0.0,
+                    width: 1200.0,
+                    height: 600.0
+                },
                 offset_x: 0.0,
                 offset_y: 0.0,
                 previous_margin_bottom: 0.0,
@@ -533,10 +534,12 @@ mod tests {
         layout(
             &mut layout_tree,
             &mut ContainingBlock {
-                x: 0.0,
-                y: 0.0,
-                width: 1200.0,
-                height: 600.0,
+                rect: Rect {
+                    x: 0.0,
+                    y: 0.0,
+                    width: 1200.0,
+                    height: 600.0
+                },
                 offset_x: 0.0,
                 offset_y: 0.0,
                 previous_margin_bottom: 0.0,

--- a/components/layout/src/box_model.rs
+++ b/components/layout/src/box_model.rs
@@ -5,7 +5,7 @@
 /// Box-model dimensions for each layout box
 #[derive(Debug, Clone)]
 pub struct Dimensions {
-    pub content: ContentArea,
+    pub content: Rect,
     pub padding: EdgeSizes,
     pub margin: EdgeSizes,
     pub border: EdgeSizes,
@@ -13,7 +13,7 @@ pub struct Dimensions {
 
 /// Size of the content area (all in px)
 #[derive(Debug, Clone)]
-pub struct ContentArea {
+pub struct Rect {
     pub width: f32,
     pub height: f32,
     pub x: f32,
@@ -124,7 +124,7 @@ impl Dimensions {
 impl Default for Dimensions {
     fn default() -> Self {
         Self {
-            content: ContentArea {
+            content: Rect {
                 width: 0.0,
                 height: 0.0,
                 x: 0.0,

--- a/components/layout/src/layout_box.rs
+++ b/components/layout/src/layout_box.rs
@@ -3,10 +3,10 @@
 /// that made up the layout tree.
 use crate::box_model::Rect;
 
+use super::box_layout::ContainingBlock;
 use super::box_model::Dimensions;
 use super::is_block_container_box;
 use style::render_tree::RenderNodeRef;
-use super::box_layout::ContainingBlock;
 
 /// LayoutBox for the layout tree
 #[derive(Debug, Clone)]

--- a/components/layout/src/layout_box.rs
+++ b/components/layout/src/layout_box.rs
@@ -1,10 +1,12 @@
-use super::box_layout::ContainingBlock;
 /// This module contains the definition of
 /// the layout box, which is the component
 /// that made up the layout tree.
+use crate::box_model::Rect;
+
 use super::box_model::Dimensions;
 use super::is_block_container_box;
 use style::render_tree::RenderNodeRef;
+use super::box_layout::ContainingBlock;
 
 /// LayoutBox for the layout tree
 #[derive(Debug, Clone)]
@@ -73,10 +75,12 @@ impl LayoutBox {
     pub fn as_containing_block(&self) -> ContainingBlock {
         let box_model = self.dimensions.clone();
         ContainingBlock {
-            x: box_model.content.x - box_model.padding.left,
-            y: box_model.content.y - box_model.padding.top,
-            width: box_model.content.width,
-            height: box_model.content.height,
+            rect: Rect {
+                x: box_model.content.x - box_model.padding.left,
+                y: box_model.content.y - box_model.padding.top,
+                width: box_model.content.width,
+                height: box_model.content.height,
+            },
             offset_x: box_model.content.x,
             offset_y: box_model.content.y,
             previous_margin_bottom: 0.0,

--- a/rendering/src/layouting.rs
+++ b/rendering/src/layouting.rs
@@ -1,7 +1,7 @@
 use css::cssom::css_rule::CSSRule;
 use css::cssom::stylesheet::StyleSheet;
 use dom::dom_ref::NodeRef;
-use layout::{build_layout_tree, layout_box::LayoutBox, ContainingBlock};
+use layout::{build_layout_tree, layout_box::LayoutBox, ContainingBlock, box_model::Rect};
 use style::render_tree::build_render_tree;
 use style::value_processing::{CSSLocation, CascadeOrigin, ContextualRule};
 
@@ -27,12 +27,14 @@ pub fn layout(dom: &NodeRef, stylesheets: &[StyleSheet], width: f32, height: f32
     layout::layout(
         &mut layout_tree,
         &mut ContainingBlock {
+            rect: Rect {
+                x: 0.,
+                y: 0.,
+                width,
+                height,
+            },
             offset_x: 0.,
             offset_y: 0.,
-            x: 0.,
-            y: 0.,
-            width,
-            height,
             previous_margin_bottom: 0.0,
             collapsed_margins_vertical: 0.0,
         },

--- a/rendering/src/layouting.rs
+++ b/rendering/src/layouting.rs
@@ -1,7 +1,7 @@
 use css::cssom::css_rule::CSSRule;
 use css::cssom::stylesheet::StyleSheet;
 use dom::dom_ref::NodeRef;
-use layout::{build_layout_tree, layout_box::LayoutBox, ContainingBlock, box_model::Rect};
+use layout::{box_model::Rect, build_layout_tree, layout_box::LayoutBox, ContainingBlock};
 use style::render_tree::build_render_tree;
 use style::value_processing::{CSSLocation, CascadeOrigin, ContextualRule};
 


### PR DESCRIPTION
This PR refactor the containing block to reuse the `Rect` struct. We currently using a temporary algo to obtain the containing block and this will be tackle next.