### PR TITLE
Improve rendering path

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -15,23 +15,19 @@ run_task = [
 	{ name = "kernel" },
 ]
 
-[tasks.start]
-workspace = false
-dependencies = ["renderer"]
-command = "cargo"
-args = ["run"]
-
 [tasks.example]
 workspace = false
-dependencies = ["renderer"]
-command = "cargo"
-args = ["run", "--", "--html", "fixtures/test.html", "--css", "fixtures/test.css"]
+dependencies = ["renderer", "kernel"]
+script = '''
+cd target/debug && ./moon --html ../../fixtures/test.html --css ../../fixtures/test.css
+'''
 
 [tasks.try]
 workspace = false
-dependencies = ["renderer"]
-command = "cargo"
-args = ["run", "--", "--html", "fixtures/${@}.html", "--css", "fixtures/${@}.css"]
+dependencies = ["renderer", "kernel"]
+script = '''
+cd target/debug && ./moon --html ../../fixtures/${@}.html --css ../../fixtures/${@}.css
+'''
 
 [tasks.output]
 workspace = false

--- a/rendering/src/paint/rect.rs
+++ b/rendering/src/paint/rect.rs
@@ -108,12 +108,12 @@ fn create_pipeline(
             color_blend: wgpu::BlendDescriptor {
                 src_factor: wgpu::BlendFactor::SrcAlpha,
                 dst_factor: wgpu::BlendFactor::OneMinusSrcAlpha,
-                operation: wgpu::BlendOperation::Add,                 
+                operation: wgpu::BlendOperation::Add,
             },
             alpha_blend: wgpu::BlendDescriptor {
                 src_factor: wgpu::BlendFactor::One,
                 dst_factor: wgpu::BlendFactor::One,
-                operation: wgpu::BlendOperation::Add,                 
+                operation: wgpu::BlendOperation::Add,
             },
             write_mask: wgpu::ColorWrite::ALL,
         }],

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -1,6 +1,7 @@
 use ipc::IpcConnection;
 use message::BrowserMessage;
 use std::process::{Child, Command};
+use std::env;
 
 pub struct RendererHandler {
     process: Child,
@@ -9,7 +10,11 @@ pub struct RendererHandler {
 
 impl RendererHandler {
     pub fn new(id: u16) -> Self {
-        let process = Command::new("target/debug/rendering")
+        let mut dir = env::current_exe().expect("Unable to obtain current path");
+        dir.pop();
+        dir.push("rendering");
+
+        let process = Command::new(dir)
             .args(&["--id", &id.to_string()])
             .spawn()
             .expect("Unable to start renderer");

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -1,7 +1,7 @@
 use ipc::IpcConnection;
 use message::BrowserMessage;
-use std::process::{Child, Command};
 use std::env;
+use std::process::{Child, Command};
 
 pub struct RendererHandler {
     process: Child,

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -10,11 +10,13 @@ pub struct RendererHandler {
 
 impl RendererHandler {
     pub fn new(id: u16) -> Self {
-        let mut dir = env::current_exe().expect("Unable to obtain current path");
-        dir.pop();
-        dir.push("rendering");
+        let mut current_dir = env::current_exe().expect("Unable to obtain current path");
+        current_dir.pop();
 
-        let process = Command::new(dir)
+        let mut renderer_path = current_dir;
+        renderer_path.push("rendering");
+
+        let process = Command::new(renderer_path)
             .args(&["--id", &id.to_string()])
             .spawn()
             .expect("Unable to start renderer");


### PR DESCRIPTION
Because we separated rendering to be another process, the kernel must know the path of the renderer to spawn it.

So I changed the kernel to always find the renderer in the same folder where the kernel is located. This will fix the problem when we actually release the app.