### PR TITLE
Use GTK drawing area for web content rendering

### DIFF
--- a/main/src/delayed_task.rs
+++ b/main/src/delayed_task.rs
@@ -1,0 +1,26 @@
+use std::{time::Duration, sync::{Arc, Mutex}};
+
+pub struct DelayedTask {
+    should_run: Arc<Mutex<bool>>
+}
+
+impl DelayedTask {
+    pub fn new<F: FnOnce() + 'static + Send + Copy>(timeout: Duration, callback: F) -> Self {
+        let should_run = Arc::new(Mutex::new(true));
+        let should_run_clone = should_run.clone();
+        let _ = std::thread::spawn(move || {
+            std::thread::sleep(timeout);
+            if !*should_run_clone.lock().unwrap() {
+                return;
+            }
+            callback();
+        });
+        Self {
+            should_run,
+        }
+    }
+
+    pub fn clear(&self) {
+        *self.should_run.lock().unwrap() = false;
+    }
+}

--- a/main/src/delayed_task.rs
+++ b/main/src/delayed_task.rs
@@ -1,7 +1,10 @@
-use std::{time::Duration, sync::{Arc, Mutex}};
+use std::{
+    sync::{Arc, Mutex},
+    time::Duration,
+};
 
 pub struct DelayedTask {
-    should_run: Arc<Mutex<bool>>
+    should_run: Arc<Mutex<bool>>,
 }
 
 impl DelayedTask {
@@ -15,9 +18,7 @@ impl DelayedTask {
             }
             callback();
         });
-        Self {
-            should_run,
-        }
+        Self { should_run }
     }
 
     pub fn clear(&self) {

--- a/main/src/lib.rs
+++ b/main/src/lib.rs
@@ -4,6 +4,7 @@ mod app;
 mod render_engine;
 mod state;
 mod ui;
+mod delayed_task;
 
 pub fn start_main() {
     let app = Application::builder()

--- a/main/src/lib.rs
+++ b/main/src/lib.rs
@@ -1,10 +1,10 @@
 use gtk::{prelude::*, Application};
 
 mod app;
+mod delayed_task;
 mod render_engine;
 mod state;
 mod ui;
-mod delayed_task;
 
 pub fn start_main() {
     let app = Application::builder()

--- a/main/src/render_engine.rs
+++ b/main/src/render_engine.rs
@@ -57,6 +57,7 @@ impl RenderEngine {
     pub fn resize(&self, size: Size) {
         self.update(|renderer| {
             renderer.resize(size);
+            renderer.paint();
             true
         });
     }

--- a/main/src/state/mod.rs
+++ b/main/src/state/mod.rs
@@ -8,7 +8,6 @@ use browser_tab::BrowserTab;
 use gtk::{
     gdk_pixbuf::{Colorspace, Pixbuf},
     glib::Bytes,
-    traits::ImageExt,
 };
 use shared::primitive::Size;
 use url::Url;
@@ -71,6 +70,6 @@ impl AppState {
             self.viewport.height as i32,
             self.viewport.width as i32 * 4,
         );
-        self.ui.content_area.set_pixbuf(Some(&pixbuf));
+        self.ui.set_content_pixbuf(pixbuf);
     }
 }

--- a/main/src/state/mod.rs
+++ b/main/src/state/mod.rs
@@ -7,7 +7,8 @@ use browser::Browser;
 use browser_tab::BrowserTab;
 use gtk::{
     gdk_pixbuf::{Colorspace, Pixbuf},
-    glib::Bytes, traits::WidgetExt,
+    glib::Bytes,
+    traits::WidgetExt,
 };
 use shared::primitive::Size;
 use url::Url;
@@ -35,7 +36,7 @@ impl AppState {
         let tab = BrowserTab::new(url.clone());
         let viewport = Size::new(
             self.ui.content_area.allocated_width() as f32,
-            self.ui.content_area.allocated_height() as f32
+            self.ui.content_area.allocated_height() as f32,
         );
         tab.resize(viewport);
         tab.load();

--- a/main/src/state/mod.rs
+++ b/main/src/state/mod.rs
@@ -7,7 +7,7 @@ use browser::Browser;
 use browser_tab::BrowserTab;
 use gtk::{
     gdk_pixbuf::{Colorspace, Pixbuf},
-    glib::Bytes,
+    glib::Bytes, traits::WidgetExt,
 };
 use shared::primitive::Size;
 use url::Url;
@@ -18,7 +18,6 @@ pub struct AppState {
     pub browser: Browser,
     tabs: Vec<BrowserTab>,
     pub active_tab: usize,
-    pub viewport: Size,
 }
 
 impl AppState {
@@ -29,13 +28,16 @@ impl AppState {
             browser: Browser::new(),
             tabs: Vec::new(),
             active_tab: 0,
-            viewport: Size::new(1200., 600.),
         }
     }
 
     pub fn new_tab(&mut self, url: Url, active: bool) -> &BrowserTab {
         let tab = BrowserTab::new(url.clone());
-        tab.resize(self.viewport.clone());
+        let viewport = Size::new(
+            self.ui.content_area.allocated_width() as f32,
+            self.ui.content_area.allocated_height() as f32
+        );
+        tab.resize(viewport);
         tab.load();
         self.tabs.push(tab);
 
@@ -66,9 +68,9 @@ impl AppState {
             Colorspace::Rgb,
             true,
             8,
-            self.viewport.width as i32,
-            self.viewport.height as i32,
-            self.viewport.width as i32 * 4,
+            self.ui.content_area.allocated_width(),
+            self.ui.content_area.allocated_height(),
+            self.ui.content_area.allocated_width() * 4,
         );
         self.ui.set_content_pixbuf(pixbuf);
     }

--- a/main/src/ui/mod.rs
+++ b/main/src/ui/mod.rs
@@ -1,15 +1,20 @@
 mod primary_bar;
 
-use gtk::{prelude::*, Orientation};
-use gtk::{Application, ApplicationWindow, Image};
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use gtk::gdk_pixbuf::Pixbuf;
+use gtk::{prelude::*, DrawingArea, Orientation};
+use gtk::{Application, ApplicationWindow};
 
 use self::primary_bar::PrimaryBar;
 
 pub struct UI {
     pub app: Application,
     pub window: ApplicationWindow,
-    pub content_area: Image,
+    pub content_area: DrawingArea,
     pub primary_bar: PrimaryBar,
+    web_content: Rc<RefCell<Option<Pixbuf>>>,
 }
 
 impl UI {
@@ -21,7 +26,21 @@ impl UI {
             .default_height(600)
             .build();
 
-        let content_area = Image::builder().hexpand(true).vexpand(true).build();
+        let content_area = DrawingArea::builder().hexpand(true).vexpand(true).build();
+
+        let web_content: Rc<RefCell<Option<Pixbuf>>> = Rc::new(RefCell::new(None));
+
+        let web_content_clone = web_content.clone();
+
+        content_area.connect_draw(move |_, context| {
+            if let Some(pixbuf) = &*web_content_clone.borrow() {
+                context.set_source_pixbuf(pixbuf, 0., 0.);
+                context.paint().unwrap();
+                return Inhibit(false);
+            }
+
+            Inhibit(true)
+        });
 
         let container = gtk::Box::builder()
             .orientation(Orientation::Vertical)
@@ -36,6 +55,12 @@ impl UI {
             window,
             content_area,
             primary_bar,
+            web_content,
         }
+    }
+
+    pub fn set_content_pixbuf(&mut self, content: Pixbuf) {
+        self.web_content.borrow_mut().replace(content);
+        self.content_area.queue_draw();
     }
 }

--- a/main/src/ui/mod.rs
+++ b/main/src/ui/mod.rs
@@ -20,7 +20,7 @@ pub struct UI {
     pub window: ApplicationWindow,
     pub content_area: DrawingArea,
     pub primary_bar: PrimaryBar,
-    web_content: Rc<RefCell<Option<Pixbuf>>>
+    web_content: Rc<RefCell<Option<Pixbuf>>>,
 }
 
 impl UI {
@@ -54,14 +54,17 @@ impl UI {
             if let Some(task) = &*debouncer.lock().unwrap() {
                 task.clear();
             }
-            debouncer.lock().unwrap().replace(DelayedTask::new(Duration::from_millis(200), || {
-                get_app_runtime().update_state(|state| {
-                    let width = state.ui.content_area.allocated_width();
-                    let height = state.ui.content_area.allocated_width();
-                    let new_size = Size::new(width as f32, height as f32);
-                    state.active_tab_mut().resize(new_size);
-                });
-            }));
+            debouncer
+                .lock()
+                .unwrap()
+                .replace(DelayedTask::new(Duration::from_millis(200), || {
+                    get_app_runtime().update_state(|state| {
+                        let width = state.ui.content_area.allocated_width();
+                        let height = state.ui.content_area.allocated_width();
+                        let new_size = Size::new(width as f32, height as f32);
+                        state.active_tab_mut().resize(new_size);
+                    });
+                }));
         });
 
         let container = gtk::Box::builder()
@@ -77,7 +80,7 @@ impl UI {
             window,
             content_area,
             primary_bar,
-            web_content
+            web_content,
         }
     }
 

--- a/render/src/renderer.rs
+++ b/render/src/renderer.rs
@@ -42,7 +42,7 @@ impl<'a> Renderer<'a> {
         rt.block_on(self.painter.output())
     }
 
-    fn paint(&mut self) {
+    pub fn paint(&mut self) {
         let main_frame = self.page.main_frame();
 
         if let Some(layout_root) = main_frame.layout().layout_tree() {


### PR DESCRIPTION
This make the web content rendered onto GTK drawing area. This enable us to support browser resizing.
![browser_resize](https://user-images.githubusercontent.com/12984316/163388984-6cebe8fa-207d-4034-9afa-d859b438cbbe.gif)
