### PR TITLE
Refactor resource loader

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1487,6 +1487,7 @@ name = "loader"
 version = "0.1.0"
 dependencies = [
  "flume",
+ "lazy_static",
  "net",
  "tokio",
  "url 0.1.0",

--- a/components/loader/Cargo.toml
+++ b/components/loader/Cargo.toml
@@ -11,3 +11,4 @@ url = { path = "../url" }
 net = { path = "../net" }
 tokio = { version = "1.6.2", features = ["rt", "rt-multi-thread"] }
 flume = "0.10.12"
+lazy_static = "1.4"

--- a/main/src/state/browser_tab.rs
+++ b/main/src/state/browser_tab.rs
@@ -197,7 +197,7 @@ impl BrowserTab {
 
     fn load_html(&self) {
         let current_url = self.info.url.lock().unwrap().clone();
-        match ResourceLoader::current().load(&current_url) {
+        match ResourceLoader::global().load(&current_url) {
             Ok(bytes) => {
                 let html = ByteString::new(&bytes);
                 self.client.load_html(html.to_string(), current_url);
@@ -210,7 +210,7 @@ impl BrowserTab {
 
     fn load_source(&self) {
         let current_url = self.info.url.lock().unwrap().clone();
-        match ResourceLoader::current().load(&current_url) {
+        match ResourceLoader::global().load(&current_url) {
             Ok(bytes) => {
                 let raw_html_string = ByteString::new(&bytes).to_string();
                 let raw_html = html_escape::encode_text(&raw_html_string);

--- a/render/src/engine.rs
+++ b/render/src/engine.rs
@@ -1,6 +1,7 @@
 use super::page::Page;
 use flume::{Receiver, Sender};
 use gfx::Bitmap;
+use loader::{ResourceLoader, RESOURCE_LOADER};
 use shared::primitive::Size;
 use url::Url;
 
@@ -16,12 +17,14 @@ pub enum OutputEvent {
 
 pub struct RenderEngine<'a> {
     page: Page<'a>,
+    res_loader: ResourceLoader,
 }
 
 impl<'a> RenderEngine<'a> {
     pub async fn new(viewport: Size) -> RenderEngine<'a> {
         let page = Page::new(viewport).await;
-        Self { page }
+        let res_loader = ResourceLoader::init();
+        Self { page, res_loader }
     }
 
     pub async fn run(
@@ -46,7 +49,11 @@ impl<'a> RenderEngine<'a> {
                 self.emit_new_frame(event_emitter)?;
             }
             InputEvent::LoadHTML { html, base_url } => {
-                self.page.load_html(html, base_url).await;
+                RESOURCE_LOADER
+                    .scope(self.res_loader.clone(), async {
+                        self.page.load_html(html, base_url).await;
+                    })
+                    .await;
                 self.emit_new_frame(event_emitter)?;
                 self.emit_new_title(event_emitter)?;
             }

--- a/render/src/page.rs
+++ b/render/src/page.rs
@@ -21,7 +21,6 @@ pub struct Page<'a> {
 
 impl<'a> Page<'a> {
     pub async fn new(init_size: Size) -> Page<'a> {
-        ResourceLoader::init();
         Page {
             main_frame: Frame::new(init_size),
             pipeline: Pipeline::new().await,


### PR DESCRIPTION
* One per RenderClient
* Add a global one for BrowserTab to use (without accessing to
  RenderClient)
* No more unsafe