### PR TITLE
Scrolling support

### DIFF
--- a/components/layout/src/flow/block.rs
+++ b/components/layout/src/flow/block.rs
@@ -47,7 +47,15 @@ impl BlockFormattingContext {
         layout_node.set_content_height(height);
         layout_node.set_offset(0., 0.);
 
-        self.layout_block_level_children(context, layout_node);
+        self.layout_block_level_children(context, layout_node.clone());
+
+        // The first child of initial block box is guarenteed to be a HTML container
+        // so we use its height as the scroll height for our initial block box.
+        let scroll_height = layout_node
+            .first_child()
+            .map(|child| LayoutBoxPtr(child).margin_box_height())
+            .unwrap_or(height);
+        layout_node.set_scroll_height(scroll_height);
     }
 
     fn layout_block_level_children(&self, context: &LayoutContext, layout_node: LayoutBoxPtr) {

--- a/components/layout/src/layout_box.rs
+++ b/components/layout/src/layout_box.rs
@@ -200,6 +200,19 @@ impl LayoutBoxPtr {
             .map(|node| LayoutBoxPtr(node));
     }
 
+    // TODO: Get parent base on overflow property instead
+    pub fn scrolling_containing_block(&self) -> Option<LayoutBoxPtr> {
+        self
+            .find_first_ancestor(|parent| parent.parent().is_none())
+            .map(|node| LayoutBoxPtr(node))
+    }
+
+    pub fn is_visible_in_scrolling_area(&self) -> bool {
+        self.scrolling_containing_block()
+            .map(|containing_block| self.padding_box_absolute().is_overlap_rect(&containing_block.absolute_rect()))
+            .unwrap_or(true)
+    }
+
     pub fn can_have_children(&self) -> bool {
         match self.data {
             BoxData::InlineContents(InlineContents::TextRun) => false,

--- a/components/painting/src/request_builder.rs
+++ b/components/painting/src/request_builder.rs
@@ -114,9 +114,10 @@ impl<'a> RequestBuilder<'a> {
                         let color = color_from_value(&node.get_style(&Property::Color));
                         let font_size = node.get_style(&Property::FontSize).to_absolute_px();
 
-                        let box_is_visible = layout_box.scrolling_containing_block().map(|block| {
-                            text_rect.is_overlap_rect(&block.absolute_rect())
-                        }).unwrap_or(true);
+                        let box_is_visible = layout_box
+                            .scrolling_containing_block()
+                            .map(|block| text_rect.is_overlap_rect(&block.absolute_rect()))
+                            .unwrap_or(true);
 
                         if !box_is_visible {
                             continue;
@@ -172,7 +173,8 @@ impl<'a> RequestBuilder<'a> {
             }
         }
 
-        let is_box_visible = layout_box.scrolling_containing_block()
+        let is_box_visible = layout_box
+            .scrolling_containing_block()
             .map(|containing_block| rect.is_overlap_rect(&containing_block.absolute_rect()))
             .unwrap_or(true);
 

--- a/components/painting/src/request_builder.rs
+++ b/components/painting/src/request_builder.rs
@@ -110,6 +110,11 @@ impl<'a> RequestBuilder<'a> {
                         let color = color_from_value(&node.get_style(&Property::Color));
                         let font_size = node.get_style(&Property::FontSize).to_absolute_px();
 
+                        // Don't render texts out side the frame
+                        if text_rect.y + text_rect.height < 0. || text_rect.y > self.canvas_size.height {
+                            continue;
+                        }
+
                         self.texts.push(PaintText {
                             content: content.to_string(),
                             color,
@@ -158,6 +163,11 @@ impl<'a> RequestBuilder<'a> {
             if self.root_element_use_body_background {
                 rect = Rect::new(0., 0., self.canvas_size.width, self.canvas_size.height);
             }
+        }
+
+        // Don't render boxes out side the frame
+        if rect.y + rect.height < 0. || rect.y > self.canvas_size.height {
+            return None;
         }
 
         let maybe_corners = self.compute_border_radius_corner(layout_box);

--- a/components/shared/src/primitive/rect.rs
+++ b/components/shared/src/primitive/rect.rs
@@ -26,9 +26,9 @@ impl Rect {
 
     pub fn is_overlap_rect(&self, other: &Rect) -> bool {
         self.x < other.x + other.width
-        && self.x + self.width > other.x
-        && self.y < other.y + other.height
-        && self.y + self.height > other.y
+            && self.x + self.width > other.x
+            && self.y < other.y + other.height
+            && self.y + self.height > other.y
     }
 
     pub fn new(x: f32, y: f32, width: f32, height: f32) -> Self {

--- a/components/shared/src/primitive/rect.rs
+++ b/components/shared/src/primitive/rect.rs
@@ -24,6 +24,13 @@ impl Rect {
         self.y += dy;
     }
 
+    pub fn is_overlap_rect(&self, other: &Rect) -> bool {
+        self.x < other.x + other.width
+        && self.x + self.width > other.x
+        && self.y < other.y + other.height
+        && self.y + self.height > other.y
+    }
+
     pub fn new(x: f32, y: f32, width: f32, height: f32) -> Self {
         Self {
             x,

--- a/fixtures/test_block_layout.html
+++ b/fixtures/test_block_layout.html
@@ -7,4 +7,20 @@
   <div class="box blue"></div>
   <div class="box purple"></div>
   <div class="box pink"></div>
+
+  <div class="box red"></div>
+  <div class="box orange"></div>
+  <div class="box yellow"></div>
+  <div class="box green"></div>
+  <div class="box blue"></div>
+  <div class="box purple"></div>
+  <div class="box pink"></div>
+
+  <div class="box red"></div>
+  <div class="box orange"></div>
+  <div class="box yellow"></div>
+  <div class="box green"></div>
+  <div class="box blue"></div>
+  <div class="box purple"></div>
+  <div class="box pink"></div>
 </div>

--- a/main/src/render_client.rs
+++ b/main/src/render_client.rs
@@ -58,7 +58,13 @@ impl RenderClient {
     pub fn resize(&self, size: Size) {
         self.event_sender
             .send(InputEvent::ViewportResize(size))
-            .expect("Unable to load HTML");
+            .expect("Unable to resize");
+    }
+
+    pub fn scroll(&self, y: f32) {
+        self.event_sender
+            .send(InputEvent::Scroll(y))
+            .expect("Unable to send scroll event");
     }
 
     pub fn load_url(&self, url: &Url) {

--- a/main/src/state/browser.rs
+++ b/main/src/state/browser.rs
@@ -29,6 +29,13 @@ impl BrowserHandler {
         });
     }
 
+    pub fn scroll(&self, y: f32) {
+        self.update(move |browser| {
+            let active_tab = browser.get_active_tab();
+            active_tab.scroll(y).unwrap();
+        });
+    }
+
     pub fn view_source_current_tab(&self) {
         self.update(|browser| {
             let active_tab = browser.get_active_tab();

--- a/main/src/state/browser_tab.rs
+++ b/main/src/state/browser_tab.rs
@@ -8,6 +8,7 @@ use url::Url;
 
 pub enum TabAction {
     Resize(Size),
+    Scroll(f32),
     Goto(Url),
     ShowError { title: String, body: String },
 }
@@ -27,6 +28,11 @@ pub struct TabHandler {
 impl TabHandler {
     pub fn resize(&self, size: Size) -> anyhow::Result<()> {
         self.sender.send(TabAction::Resize(size))?;
+        Ok(())
+    }
+
+    pub fn scroll(&self, y: f32) -> anyhow::Result<()> {
+        self.sender.send(TabAction::Scroll(y))?;
         Ok(())
     }
 
@@ -120,6 +126,7 @@ impl BrowserTab {
     fn handle_tab_action(&self, event: TabAction) -> anyhow::Result<()> {
         match event {
             TabAction::Resize(new_size) => self.client.resize(new_size),
+            TabAction::Scroll(y) => self.client.scroll(y),
             TabAction::Goto(url) => self.goto(url)?,
             TabAction::ShowError { title, body } => self.load_error(&title, &body),
         }

--- a/main/src/ui/content_area.rs
+++ b/main/src/ui/content_area.rs
@@ -26,7 +26,7 @@ impl ContentArea {
         let render_area = DrawingArea::builder()
             .hexpand(true)
             .vexpand(true)
-            .events(EventMask::BUTTON_PRESS_MASK)
+            .events(EventMask::BUTTON_PRESS_MASK | EventMask::SMOOTH_SCROLL_MASK)
             .build();
 
         let web_content_pixbuf: Rc<RefCell<Option<Pixbuf>>> = Rc::new(RefCell::new(None));
@@ -59,6 +59,15 @@ impl ContentArea {
                         state.browser().resize(new_size);
                     });
                 }));
+        });
+
+        render_area.connect_scroll_event(move |_, event| {
+            let delta_y = event.delta().1 as f32;
+            get_app_runtime().update_state(move |state| {
+                state.browser().scroll(delta_y * 1.2);
+            });
+
+            Inhibit(false)
         });
 
         render_area.connect_button_press_event(|_, event| {

--- a/render/src/engine.rs
+++ b/render/src/engine.rs
@@ -7,6 +7,7 @@ use url::Url;
 
 pub enum InputEvent {
     ViewportResize(Size),
+    Scroll(f32),
     LoadHTML { html: String, base_url: Url },
     LoadURL(Url),
 }
@@ -51,6 +52,10 @@ impl<'a> RenderEngine<'a> {
         match event {
             InputEvent::ViewportResize(new_size) => {
                 self.page.resize(new_size).await;
+                self.emit_new_frame(event_emitter)?;
+            }
+            InputEvent::Scroll(delta_y) => {
+                self.page.scroll(delta_y).await;
                 self.emit_new_frame(event_emitter)?;
             }
             InputEvent::LoadHTML { html, base_url } => {

--- a/render/src/frame.rs
+++ b/render/src/frame.rs
@@ -29,7 +29,7 @@ impl Frame {
             pipeline,
             PipelineRunOptions {
                 skip_style_calculation: true,
-                skip_layout_calculation: false
+                skip_layout_calculation: false,
             },
         )
         .await;
@@ -44,14 +44,14 @@ impl Frame {
         }
 
         if !need_redraw {
-            return
+            return;
         }
 
         self.render_frame(
             pipeline,
             PipelineRunOptions {
                 skip_style_calculation: true,
-                skip_layout_calculation: true
+                skip_layout_calculation: true,
             },
         )
         .await;
@@ -63,7 +63,7 @@ impl Frame {
             pipeline,
             PipelineRunOptions {
                 skip_style_calculation: false,
-                skip_layout_calculation: false
+                skip_layout_calculation: false,
             },
         )
         .await;

--- a/render/src/frame.rs
+++ b/render/src/frame.rs
@@ -29,6 +29,29 @@ impl Frame {
             pipeline,
             PipelineRunOptions {
                 skip_style_calculation: true,
+                skip_layout_calculation: false
+            },
+        )
+        .await;
+    }
+
+    pub async fn scroll(&mut self, delta_y: f32, pipeline: &mut Pipeline<'_>) {
+        let mut need_redraw = false;
+
+        // TODO: Handle scrolling for other overflow element within the current frame's document
+        if let Some(root_node) = pipeline.content() {
+            need_redraw = root_node.scroll(delta_y);
+        }
+
+        if !need_redraw {
+            return
+        }
+
+        self.render_frame(
+            pipeline,
+            PipelineRunOptions {
+                skip_style_calculation: true,
+                skip_layout_calculation: true
             },
         )
         .await;
@@ -40,6 +63,7 @@ impl Frame {
             pipeline,
             PipelineRunOptions {
                 skip_style_calculation: false,
+                skip_layout_calculation: false
             },
         )
         .await;

--- a/render/src/page.rs
+++ b/render/src/page.rs
@@ -35,6 +35,10 @@ impl<'a> Page<'a> {
         self.main_frame.resize(size, &mut self.pipeline).await;
     }
 
+    pub async fn scroll(&mut self, y: f32) {
+        self.main_frame.scroll(y, &mut self.pipeline).await;
+    }
+
     pub async fn load_html(
         &mut self,
         html: String,


### PR DESCRIPTION
This PR added initial support for scrolling. There are a few limitation at the moment:
- No scroll bar rendering
- Only scroll the initial containing block & not other elements within it.
- Quite slow for some reason. Could be due to rendering but could also be something else.