### PR TITLE
Moved error displaying function to renderer

### DIFF
--- a/main/src/render_client.rs
+++ b/main/src/render_client.rs
@@ -2,7 +2,6 @@ use flume::{Receiver, Sender};
 use shared::primitive::Size;
 
 use render::{InputEvent, OutputEvent, RenderEngine};
-use url::Url;
 
 pub struct RenderClient {
     event_sender: Sender<InputEvent>,
@@ -49,12 +48,6 @@ impl RenderClient {
         self.event_receiver.clone()
     }
 
-    pub fn load_html(&self, html: String, base_url: Url) {
-        self.event_sender
-            .send(InputEvent::LoadHTML { html, base_url })
-            .expect("Unable to load HTML");
-    }
-
     pub fn resize(&self, size: Size) {
         self.event_sender
             .send(InputEvent::ViewportResize(size))
@@ -67,9 +60,9 @@ impl RenderClient {
             .expect("Unable to send scroll event");
     }
 
-    pub fn load_url(&self, url: &Url) {
+    pub fn load_raw_url(&self, url: String) {
         self.event_sender
-            .send(InputEvent::LoadURL(url.clone()))
+            .send(InputEvent::LoadRawURL(url))
             .expect("Unable to load URL");
     }
 

--- a/main/src/state/browser.rs
+++ b/main/src/state/browser.rs
@@ -53,9 +53,7 @@ impl BrowserHandler {
             }
 
             let url = format!("view-source:{}", active_tab_url);
-            active_tab
-                .goto(URLParser::parse(&url, None).unwrap())
-                .unwrap();
+            active_tab.goto(url).unwrap();
         });
     }
 
@@ -66,17 +64,7 @@ impl BrowserHandler {
 
         self.update(move |browser| {
             let active_tab = browser.get_active_tab();
-
-            if let Some(url) = URLParser::parse(&raw_url, None) {
-                active_tab.goto(url).unwrap();
-            } else {
-                active_tab
-                    .show_error(
-                        "Invalid URL".to_string(),
-                        format!("Invalid URL entered: {}", raw_url),
-                    )
-                    .unwrap();
-            }
+            active_tab.goto(raw_url).unwrap();
         });
     }
 
@@ -138,7 +126,7 @@ impl Browser {
 
     pub fn run(mut self) -> anyhow::Result<()> {
         let active_tab = self.get_active_tab();
-        active_tab.goto(self.home_url.clone()).unwrap();
+        active_tab.goto(self.home_url.to_string()).unwrap();
 
         enum Event {
             UpdateEvent(BrowserAction),


### PR DESCRIPTION
Moved error displaying function from main process to render process instead. This make reporting errors when tab crash easier.